### PR TITLE
CVSL-1623 Adding use of web token

### DIFF
--- a/helm_deploy/hmpps-hdc-api/values.yaml
+++ b/helm_deploy/hmpps-hdc-api/values.yaml
@@ -22,6 +22,7 @@ generic-service:
     SPRING_PROFILES_ACTIVE: "logstash"
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY)"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
+    HMPPS_SQS_USE_WEB_TOKEN: "true"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:


### PR DESCRIPTION
Was receiving this:

```
***************************
APPLICATION FAILED TO START
***************************

Description:

Failed to bind properties under 'hmpps.sqs' to uk.gov.justice.hmpps.sqs.HmppsSqsProperties:

    Reason: uk.gov.justice.hmpps.sqs.InvalidHmppsSqsPropertiesException: queueId domaineventsqueue does not have a queue access key id
```

And it was due to not using irsa. 
This env tells the spring library to use IRSA instead!