### PR TITLE
CVSL-2032 add api call

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/prison/Prison.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/prison/Prison.kt
@@ -2,10 +2,10 @@ package uk.gov.justice.digital.hmpps.hmppshdcapi.licences.prison
 
 data class PrisonContactDetails(
   val agencyId: String,
-  val phones: Telephone
+  val phones: Telephone,
 )
 
 data class Telephone(
   val number: String,
-  val type: String
+  val type: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/prison/Prison.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/prison/Prison.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.hmppshdcapi.licences.prison
+
+data class PrisonContactDetails(
+  val agencyId: String,
+  val phones: Telephone
+)
+
+data class Telephone(
+  val number: String,
+  val type: String
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/prison/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/prison/PrisonApiClient.kt
@@ -29,6 +29,19 @@ class PrisonApiClient(@Qualifier("oauthPrisonClient") val prisonerSearchApiWebCl
     return booking
   }
 
+  fun getPrisonContactDetails(agencyId: String): PrisonContactDetails? {
+    val contactDetails = prisonerSearchApiWebClient
+      .get()
+      .uri("/agencies/prison/{agencyId}", agencyId)
+      .accept(MediaType.APPLICATION_JSON)
+      .retrieve()
+      .bodyToMono(PrisonContactDetails::class.java)
+      .onErrorResume(::coerce404ResponseToNull)
+      .block()
+
+    return contactDetails
+  }
+
   fun resetHdcChecks(bookingId: Long): Boolean {
     val response = prisonerSearchApiWebClient
       .delete()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/integration/wiremock/PrisonApiMockServer.kt
@@ -11,6 +11,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import org.springframework.http.HttpStatusCode
 import uk.gov.justice.digital.hmpps.hmppshdcapi.licences.prison.Booking
+import uk.gov.justice.digital.hmpps.hmppshdcapi.licences.prison.PrisonContactDetails
 
 class PrisonApiMockServer : WireMockServer(8091) {
   private val mapper: ObjectMapper = JsonMapper.builder().findAndAddModules().build()
@@ -23,6 +24,20 @@ class PrisonApiMockServer : WireMockServer(8091) {
             "application/json",
           ).withBody(
             mapper.writeValueAsString(booking),
+          ).withStatus(200),
+        ),
+    )
+  }
+
+  fun stubGetPrisonContactDetails(prisonContactDetails: PrisonContactDetails) {
+    stubFor(
+      get(urlPathEqualTo("/api//agencies/prison/${prisonContactDetails.agencyId}"))
+        .willReturn(
+          aResponse().withHeader(
+            "Content-Type",
+            "application/json",
+          ).withBody(
+            mapper.writeValueAsString(prisonContactDetails),
           ).withStatus(200),
         ),
     )


### PR DESCRIPTION
This PR is to add a call to the Prison API to get contact details for a prison. This is a requirement for future HDC API work when creating a HDC licence in CVL.