### PR TITLE
CVSL-2033 throw exception if licence data cannot be found

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/config/HmppsHdcApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/config/HmppsHdcApiExceptionHandler.kt
@@ -47,10 +47,10 @@ class HmppsHdcApiExceptionHandler {
     .body(
       ErrorResponse(
         status = NOT_FOUND,
-        userMessage = "Validation failure: ${e.message}",
+        userMessage = "No resource found failure: ${e.message}",
         developerMessage = e.message,
       ),
-    ).also { log.info("Validation exception: {}", e.message) }
+    ).also { log.info("No resource found exception: {}", e.message) }
 
   @ExceptionHandler(HandlerMethodValidationException::class)
   fun handleHandlerMethodValidationException(e: HandlerMethodValidationException): ResponseEntity<ErrorResponse> =
@@ -78,6 +78,19 @@ class HmppsHdcApiExceptionHandler {
         developerMessage = e.message,
       ),
     ).also { log.error("Unexpected exception", e) }
+
+  @ExceptionHandler(NoDataFoundException::class)
+  fun handleNoDataFoundException(e: NoDataFoundException): ResponseEntity<ErrorResponse> = ResponseEntity
+    .status(NOT_FOUND)
+    .body(
+      ErrorResponse(
+        status = NOT_FOUND,
+        userMessage = "Data not found: ${e.message}",
+        developerMessage = e.message,
+      ),
+    ).also { log.info("Data not found exception: {}", e.message) }
+
+  class NoDataFoundException(dataType: String, idType: String, id: Long) : Exception("No $dataType found for $idType $id")
 
   private companion object {
     private val log = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/LicenceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/LicenceController.kt
@@ -82,7 +82,16 @@ class LicenceController(private val licenceService: LicenceService) {
           ),
         ],
       ),
-
+      ApiResponse(
+        responseCode = "404",
+        description = "The licence data for this booking ID was not found",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
       ApiResponse(
         responseCode = "500",
         description = "Unexpected error occurred",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/LicenceService.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppshdcapi.licences
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppshdcapi.config.HmppsHdcApiExceptionHandler.NoDataFoundException
 import uk.gov.justice.digital.hmpps.hmppshdcapi.model.HdcLicence
 
 @Service
@@ -11,12 +11,12 @@ class LicenceService(
   private val objectMapper: ObjectMapper,
 ) {
   fun getByBookingId(bookingId: Long): HdcLicence? {
-    val licenceObject = licenceRepository.findLicenceByBookingId(bookingId) ?: return null
+    val licenceObject = licenceRepository.findLicenceByBookingId(bookingId)
 
-    val licence = licenceObject.licence
+    val licence = licenceObject?.licence
 
     if (licence.isNullOrEmpty()) {
-      throw EntityNotFoundException("Licence data not found for booking $bookingId")
+      throw NoDataFoundException("licence data", "booking id", bookingId)
     }
 
     val cas2ReferralObject = licence["bassReferral"]

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/LicenceService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppshdcapi.licences
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppshdcapi.model.HdcLicence
 
@@ -15,7 +16,7 @@ class LicenceService(
     val licence = licenceObject.licence
 
     if (licence.isNullOrEmpty()) {
-      return null
+      throw EntityNotFoundException("Licence data not found for booking $bookingId")
     }
 
     val cas2ReferralObject = licence["bassReferral"]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/LicenceServiceTest.kt
@@ -4,14 +4,17 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.time.LocalDateTime
 
 class LicenceServiceTest {
   private val licenceRepository = mock<LicenceRepository>()
@@ -193,14 +196,16 @@ class LicenceServiceTest {
   }
 
   @Test
-  fun `will return early if no HDC licence`() {
-    whenever(licenceRepository.findLicenceByBookingId(54321L)).thenReturn(null)
+  fun `will throw exception if no HDC licence`() {
+    whenever(licenceRepository.findLicenceByBookingId(54321L)).thenReturn(anExceptionLicence())
 
-    val result = service.getByBookingId(54321L)
+    val exception = assertThrows<EntityNotFoundException> {
+      service.getByBookingId(54321L)
+    }
 
-    assertThat(result).isNull()
+    assertThat(exception).isInstanceOf(EntityNotFoundException::class.java)
 
-    verify(licenceRepository, times(1)).findLicenceByBookingId(54321L)
+    verify(licenceRepository, times(1)).findLicenceByBookingId(anExceptionLicence().bookingId)
   }
 
   @Test
@@ -357,6 +362,20 @@ class LicenceServiceTest {
         "Town 5",
         "KL5 5MN",
       ),
+    )
+
+    fun anExceptionLicence() = Licence(
+      id = 1,
+      prisonNumber = "A12345B",
+      bookingId = 54321,
+      stage = "MODIFIED",
+      version = 1,
+      transitionDate = LocalDateTime.of(2023, 10, 22, 10, 15),
+      varyVersion = 0,
+      additionalConditionsVersion = null,
+      standardConditionsVersion = null,
+      deletedAt = null,
+      licence = null,
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/LicenceServiceTest.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -14,6 +13,7 @@ import org.mockito.kotlin.reset
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppshdcapi.config.HmppsHdcApiExceptionHandler.NoDataFoundException
 import java.time.LocalDateTime
 
 class LicenceServiceTest {
@@ -196,14 +196,15 @@ class LicenceServiceTest {
   }
 
   @Test
-  fun `will throw exception if no HDC licence`() {
+  fun `will throw exception if no HDC licence data found`() {
     whenever(licenceRepository.findLicenceByBookingId(54321L)).thenReturn(anExceptionLicence())
 
-    val exception = assertThrows<EntityNotFoundException> {
+    val exception = assertThrows<NoDataFoundException> {
       service.getByBookingId(54321L)
     }
 
-    assertThat(exception).isInstanceOf(EntityNotFoundException::class.java)
+    assertThat(exception).isInstanceOf(NoDataFoundException::class.java)
+    assertThat(exception.message).isEqualTo("No licence data found for booking id 54321")
 
     verify(licenceRepository, times(1)).findLicenceByBookingId(anExceptionLicence().bookingId)
   }


### PR DESCRIPTION
This PR is to throw an exception where licence data cannot be found for a licence. This means that we can catch the error on the CVL API meaning better error handling. 