### PR TITLE
CVSL-2599 account for blank address lines for curfew address

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/LicenceService.kt
@@ -116,7 +116,7 @@ class LicenceService(
       return null
     }
 
-    val missingAddressFields = address.getNullAddressFields()
+    val missingAddressFields = address.getMissingAddressFields()
 
     return if (missingAddressFields.isNotEmpty()) {
       log.info("Missing $missingAddressFields address field(s) for licence $licenceId")
@@ -126,15 +126,15 @@ class LicenceService(
     }
   }
 
-  fun Address.getNullAddressFields(): List<String> {
+  fun Address.getMissingAddressFields(): List<String> {
     val missingFields = mutableListOf<String>()
-    if (addressLine1 == null) {
+    if (addressLine1.isNullOrBlank()) {
       missingFields += "addressLine1"
     }
-    if (addressTown == null) {
+    if (addressTown.isNullOrBlank()) {
       missingFields += "addressTown"
     }
-    if (postCode == null) {
+    if (postCode.isNullOrBlank()) {
       missingFields += "postCode"
     }
     return missingFields

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/LicenceServiceTest.kt
@@ -524,13 +524,13 @@ class LicenceServiceTest {
     }
 
     @Test
-    fun `test getAddress will return null when multiple address fields are null`() {
+    fun `test getAddress will return null when multiple address fields are blank`() {
       val aCurfewWithMultipleMissingAddressLines = aCurfew.copy(
         approvedPremisesAddress = CurfewAddress(
-          addressLine1 = null,
+          addressLine1 = "",
           addressLine2 = null,
           addressTown = "Town 1",
-          postCode = null,
+          postCode = "",
         ),
       )
 


### PR DESCRIPTION
This PR is to add logic to capture address lines which may be returned as blank when returning a curfew address.