### PR TITLE
CVSL-2596 change model to include county and change names of variables

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/model/CurfewAddress.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/model/CurfewAddress.kt
@@ -11,9 +11,12 @@ data class CurfewAddress(
   @Schema(description = "The second line of the curfew address", example = "Off Some Road")
   val addressLine2: String? = null,
 
-  @Schema(description = "The town associated with the curfew address", example = "Some Town")
-  val addressTown: String? = null,
+  @Schema(description = "The town or city associated with the curfew address", example = "Some Town")
+  val townOrCity: String? = null,
+
+  @Schema(description = "The county associated with the curfew address", example = "Some County")
+  val county: String? = null,
 
   @Schema(description = "The postcode for the curfew address", example = "SO30 2UH")
-  val postCode: String? = null,
+  val postcode: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/model/ToModelTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/model/ToModelTransformers.kt
@@ -13,8 +13,9 @@ fun transformToModelCurfewAddress(
 ): ModelCurfewAddress = ModelCurfewAddress(
   addressLine1 = address.addressLine1,
   addressLine2 = address.addressLine2,
-  addressTown = address.addressTown,
-  postCode = address.postCode,
+  townOrCity = address.addressTown,
+  county = null,
+  postcode = address.postCode,
 )
 
 fun transformToModelCurfewTimes(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/controllers/LicenceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/controllers/LicenceControllerTest.kt
@@ -82,8 +82,8 @@ class LicenceControllerTest {
       CurfewAddress(
         addressLine1 = "123 Approved Premises Street 2",
         addressLine2 = "Off St Michaels Place",
-        addressTown = "Leeds",
-        postCode = "LS1 2AA",
+        townOrCity = "Leeds",
+        postcode = "LS1 2AA",
       ),
       FirstNight(
         firstNightFrom = LocalTime.of(15, 0),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/integration/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/integration/LicenceServiceTest.kt
@@ -40,6 +40,7 @@ class LicenceServiceTest : SqsIntegrationTestBase() {
         "1 Test Street",
         "Test Area",
         "Test Town",
+        null,
         "T33 3ST",
       ),
     )
@@ -92,6 +93,7 @@ class LicenceServiceTest : SqsIntegrationTestBase() {
         "2 Test Road",
         null,
         "Another Town",
+        null,
         "AB1 2CD",
       ),
     )
@@ -126,6 +128,7 @@ class LicenceServiceTest : SqsIntegrationTestBase() {
         "100 CAS2 Street",
         "The Avenue",
         "Leeds",
+        null,
         "LS3 4BB",
       ),
     )
@@ -160,6 +163,7 @@ class LicenceServiceTest : SqsIntegrationTestBase() {
         "123 Approved Premises Street 2",
         "Off St Michaels Place",
         "Leeds",
+        null,
         "LS1 2AA",
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/LicenceServiceTest.kt
@@ -42,6 +42,7 @@ class LicenceServiceTest {
         "4 The Street",
         "Area 4",
         "Town 4",
+        null,
         "MN4 5OP",
       ),
     )
@@ -112,6 +113,7 @@ class LicenceServiceTest {
         "3 The Avenue",
         "Area 3",
         "Town 3",
+        null,
         "IJ3 4KL",
       ),
     )
@@ -184,6 +186,7 @@ class LicenceServiceTest {
         "2 The Street",
         "Area 2",
         "Town 2",
+        null,
         "EF3 4GH",
       ),
     )
@@ -257,6 +260,7 @@ class LicenceServiceTest {
         "1 The Street",
         "Area",
         "Town",
+        null,
         "AB1 2CD",
       ),
     )
@@ -328,6 +332,7 @@ class LicenceServiceTest {
         "2 The Street",
         null,
         "Town 2",
+        null,
         "EF3 4GH",
       ),
     )
@@ -398,8 +403,8 @@ class LicenceServiceTest {
       with(aCurfew.approvedPremisesAddress!!) {
         assertThat(result.addressLine1).isEqualTo(addressLine1)
         assertThat(result.addressLine2).isEqualTo(addressLine2)
-        assertThat(result.addressTown).isEqualTo(addressTown)
-        assertThat(result.postCode).isEqualTo(postCode)
+        assertThat(result.townOrCity).isEqualTo(addressTown)
+        assertThat(result.postcode).isEqualTo(postCode)
       }
     }
 
@@ -411,8 +416,8 @@ class LicenceServiceTest {
       with(aCas2Referral.approvedPremisesAddress!!) {
         assertThat(result.addressLine1).isEqualTo(addressLine1)
         assertThat(result.addressLine2).isEqualTo(addressLine2)
-        assertThat(result.addressTown).isEqualTo(addressTown)
-        assertThat(result.postCode).isEqualTo(postCode)
+        assertThat(result.townOrCity).isEqualTo(addressTown)
+        assertThat(result.postcode).isEqualTo(postCode)
       }
     }
 
@@ -429,8 +434,8 @@ class LicenceServiceTest {
       with(aCas2Referral.bassOffer!!) {
         assertThat(result.addressLine1).isEqualTo(addressLine1)
         assertThat(result.addressLine2).isEqualTo(addressLine2)
-        assertThat(result.addressTown).isEqualTo(addressTown)
-        assertThat(result.postCode).isEqualTo(postCode)
+        assertThat(result.townOrCity).isEqualTo(addressTown)
+        assertThat(result.postcode).isEqualTo(postCode)
       }
     }
 
@@ -455,8 +460,8 @@ class LicenceServiceTest {
       with(aProposedAddress.curfewAddress!!) {
         assertThat(result.addressLine1).isEqualTo(addressLine1)
         assertThat(result.addressLine2).isEqualTo(addressLine2)
-        assertThat(result.addressTown).isEqualTo(addressTown)
-        assertThat(result.postCode).isEqualTo(postCode)
+        assertThat(result.townOrCity).isEqualTo(addressTown)
+        assertThat(result.postcode).isEqualTo(postCode)
       }
     }
 
@@ -492,8 +497,8 @@ class LicenceServiceTest {
       with(curfewAddress) {
         assertThat(result.addressLine1).isEqualTo(addressLine1)
         assertThat(result.addressLine2).isEqualTo(addressLine2)
-        assertThat(result.addressTown).isEqualTo(addressTown)
-        assertThat(result.postCode).isEqualTo(postCode)
+        assertThat(result.townOrCity).isEqualTo(addressTown)
+        assertThat(result.postcode).isEqualTo(postCode)
       }
     }
 


### PR DESCRIPTION
This PR is to adjust the model which returns a curfew address from the API. This is to match what will be stored in CVL for curfew addresses.