### PR TITLE
CVSL-4135 HDC | Migration - adding in lastPrisonId instead of prisonI…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/migration/MigrationProcessService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/migration/MigrationProcessService.kt
@@ -129,30 +129,6 @@ class MigrationProcessService(
     }
   }
 
-  private fun performPrisonerSearchByBookingId(licenceDetails: List<LicenceBookingDetail>): Map<Long, Prisoner> {
-    log.info("HDC migration: Fetching prisoner details for booking ids {}", licenceDetails.map { it.bookingId })
-    val bookingIds = licenceDetails.map { it.bookingId }.toList()
-
-    try {
-      val prisoners = prisonSearchApiClient.getPrisonersByBookingIds(bookingIds).associateBy { it.bookingId.toLong() }
-      licenceDetails.forEach { licenceDetail ->
-        if (!prisoners.containsKey(licenceDetail.bookingId)) {
-          logFailure(
-            licenceDetail.licenceVersionId,
-            licenceDetail.bookingId,
-            "Prisoner not found for booking id ${licenceDetail.bookingId}",
-            retry = false,
-            MigrationErrorSource.HDC,
-          )
-        }
-      }
-      return prisoners
-    } catch (e: Exception) {
-      log.error("HDC migration: Error fetching prisoner details for booking ids $bookingIds", e)
-      throw e
-    }
-  }
-
   private fun performPrisonerSearchByPrisonNumber(licenceDetails: List<LicenceBookingDetail>): Map<Long, Prisoner> {
     log.info("HDC migration: Fetching prisoner details for prison number {}", licenceDetails.map { it.bookingId })
     val prisonNumbers = licenceDetails.map { it.prisonNumber }.toList()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/migration/MigrationRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/migration/MigrationRequestService.kt
@@ -128,7 +128,7 @@ class MigrationRequestService(
   )
 
   private fun mapPrisonDetails(prisoner: Prisoner) = MigratePrisonDetails(
-    prisonCode = prisoner.prisonId,
+    prisonCode = prisoner.lastPrisonId,
     prisonDescription = prisoner.prisonName ?: prisoner.locationDescription,
     prisonTelephone = null,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/migration/MigrationRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/migration/MigrationRequestService.kt
@@ -129,8 +129,6 @@ class MigrationRequestService(
 
   private fun mapPrisonDetails(prisoner: Prisoner) = MigratePrisonDetails(
     prisonCode = prisoner.lastPrisonId,
-    prisonDescription = prisoner.prisonName ?: prisoner.locationDescription,
-    prisonTelephone = null,
   )
 
   private fun mapSentenceDetails(prisoner: Prisoner) = MigrateSentenceDetails(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/migration/MigrationRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/migration/MigrationRequestService.kt
@@ -128,7 +128,7 @@ class MigrationRequestService(
   )
 
   private fun mapPrisonDetails(prisoner: Prisoner) = MigratePrisonDetails(
-    prisonCode = prisoner.lastPrisonId,
+    prisonCode = prisoner.lastPrisonId ?: throw MigrationValidationException("Prison code not found for prisoner: ${prisoner.prisonerNumber}"),
   )
 
   private fun mapSentenceDetails(prisoner: Prisoner) = MigrateSentenceDetails(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/migration/request/MigrateFromHdcToCvlRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/migration/request/MigrateFromHdcToCvlRequest.kt
@@ -86,7 +86,7 @@ data class MigrateFromHdcToCvlRequest(
 @Schema(description = "Prison details")
 data class MigratePrisonDetails(
   @field:Schema(description = "Prison code", example = "MDI")
-  val prisonCode: String?,
+  val prisonCode: String,
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/migration/request/MigrateFromHdcToCvlRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/migration/request/MigrateFromHdcToCvlRequest.kt
@@ -87,12 +87,6 @@ data class MigrateFromHdcToCvlRequest(
 data class MigratePrisonDetails(
   @field:Schema(description = "Prison code", example = "MDI")
   val prisonCode: String?,
-
-  @field:Schema(description = "Prison description", example = "HMP Example")
-  val prisonDescription: String?,
-
-  @field:Schema(description = "Prison telephone number", example = "02038219211")
-  val prisonTelephone: String?,
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/prison/Prisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/prison/Prisoner.kt
@@ -7,6 +7,7 @@ data class Prisoner(
   val prisonerNumber: String,
   val bookingId: String,
   val prisonId: String?,
+  var lastPrisonId: String?,
   @field:JsonFormat(pattern = "yyyy-MM-dd")
   val topupSupervisionExpiryDate: LocalDate?,
   @field:JsonFormat(pattern = "yyyy-MM-dd")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/integration/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/integration/LicenceServiceTest.kt
@@ -337,12 +337,13 @@ class LicenceServiceTest : SqsIntegrationTestBase() {
             prisonerNumber = "A1234AA",
             bookingId = bookingId.toString(),
             prisonId = "MDI",
+            lastPrisonId = "MDI",
             topupSupervisionExpiryDate = LocalDate.now(),
             licenceExpiryDate = LocalDate.now().minusDays(1),
             homeDetentionCurfewEligibilityDate = LocalDate.now().minusDays(2),
           ),
-          Prisoner("A1234CC", "30", "MDI", topupSupervisionExpiryDate = null, licenceExpiryDate = LocalDate.now(), homeDetentionCurfewEligibilityDate = LocalDate.now().minusDays(2)),
-          Prisoner("A1234EE", "50", "MDI", topupSupervisionExpiryDate = null, licenceExpiryDate = null, homeDetentionCurfewEligibilityDate = LocalDate.now().minusDays(2)),
+          Prisoner("A1234CC", "30", "MDI", "MDI", topupSupervisionExpiryDate = null, licenceExpiryDate = LocalDate.now(), homeDetentionCurfewEligibilityDate = LocalDate.now().minusDays(2)),
+          Prisoner("A1234EE", "50", "MDI", "MDI", topupSupervisionExpiryDate = null, licenceExpiryDate = null, homeDetentionCurfewEligibilityDate = LocalDate.now().minusDays(2)),
         ),
       )
       prisonApiMockServer.getHdcStatuses(listOf(bookingId to approvalStatus))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/integration/SoftDeleteJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/integration/SoftDeleteJobTest.kt
@@ -46,12 +46,13 @@ class SoftDeleteJobTest : SqsIntegrationTestBase() {
           "A1234AA",
           "10",
           "MDI",
+          "MDI",
           topupSupervisionExpiryDate = LocalDate.now(),
           licenceExpiryDate = LocalDate.now().minusDays(1),
           homeDetentionCurfewEligibilityDate = LocalDate.now().minusDays(2),
         ),
-        Prisoner("A1234CC", "30", "MDI", topupSupervisionExpiryDate = null, licenceExpiryDate = LocalDate.now(), homeDetentionCurfewEligibilityDate = LocalDate.now().minusDays(2)),
-        Prisoner("A1234EE", "50", "MDI", topupSupervisionExpiryDate = null, licenceExpiryDate = null, homeDetentionCurfewEligibilityDate = LocalDate.now().minusDays(2)),
+        Prisoner("A1234CC", "30", "MDI", "MDI", topupSupervisionExpiryDate = null, licenceExpiryDate = LocalDate.now(), homeDetentionCurfewEligibilityDate = LocalDate.now().minusDays(2)),
+        Prisoner("A1234EE", "50", "MDI", "MDI", topupSupervisionExpiryDate = null, licenceExpiryDate = null, homeDetentionCurfewEligibilityDate = LocalDate.now().minusDays(2)),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/integration/SoftDeleteMigrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/integration/SoftDeleteMigrationTest.kt
@@ -40,9 +40,9 @@ class SoftDeleteMigrationTest : SqsIntegrationTestBase() {
   fun `Perform migration`() {
     prisonerSearchMockServer.stubSearchPrisonersByBookingIds(
       listOf(
-        Prisoner("A1234AA", "10", "MDI", topupSupervisionExpiryDate = LocalDate.now(), licenceExpiryDate = LocalDate.now().minusDays(1), homeDetentionCurfewEligibilityDate = LocalDate.now().minusDays(2)),
-        Prisoner("A1234CC", "30", "MDI", topupSupervisionExpiryDate = null, licenceExpiryDate = LocalDate.now(), homeDetentionCurfewEligibilityDate = LocalDate.now().minusDays(2)),
-        Prisoner("A1234EE", "50", "MDI", topupSupervisionExpiryDate = null, licenceExpiryDate = null, homeDetentionCurfewEligibilityDate = LocalDate.now().minusDays(2)),
+        Prisoner("A1234AA", "10", "MDI", "MDI", topupSupervisionExpiryDate = LocalDate.now(), licenceExpiryDate = LocalDate.now().minusDays(1), homeDetentionCurfewEligibilityDate = LocalDate.now().minusDays(2)),
+        Prisoner("A1234CC", "30", "MDI", "MDI", topupSupervisionExpiryDate = null, licenceExpiryDate = LocalDate.now(), homeDetentionCurfewEligibilityDate = LocalDate.now().minusDays(2)),
+        Prisoner("A1234EE", "50", "MDI", "MDI", topupSupervisionExpiryDate = null, licenceExpiryDate = null, homeDetentionCurfewEligibilityDate = LocalDate.now().minusDays(2)),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/integration/migration/MigrationBatchControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/integration/migration/MigrationBatchControllerTest.kt
@@ -284,7 +284,8 @@ class MigrationBatchControllerTest : SqsIntegrationTestBase() {
   ) = Prisoner(
     prisonerNumber = prisonerNumber,
     bookingId = bookingId,
-    prisonId = "MDI",
+    prisonId = "AWE",
+    lastPrisonId = "MDI",
     topupSupervisionExpiryDate = LocalDate.of(2028, 2, 10),
     licenceExpiryDate = LocalDate.of(2028, 3, 30),
     homeDetentionCurfewActualDate = LocalDate.of(2025, 4, 30),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/integration/migration/MigrationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/integration/migration/MigrationControllerTest.kt
@@ -369,7 +369,8 @@ class MigrationControllerTest : SqsIntegrationTestBase() {
       Prisoner(
         prisonerNumber = "A1234AA",
         bookingId = "54222",
-        prisonId = "MDI",
+        prisonId = "ADI",
+        lastPrisonId = "MDI",
         topupSupervisionExpiryDate = LocalDate.of(2028, 2, 10),
         licenceExpiryDate = LocalDate.of(2028, 3, 30),
         homeDetentionCurfewActualDate = LocalDate.of(2025, 4, 30),
@@ -407,7 +408,8 @@ class MigrationControllerTest : SqsIntegrationTestBase() {
       Prisoner(
         prisonerNumber = "A1234CC",
         bookingId = "30",
-        prisonId = "MDI",
+        prisonId = "ADI",
+        lastPrisonId = "MDI",
         topupSupervisionExpiryDate = null,
         licenceExpiryDate = LocalDate.of(2025, 4, 1),
         homeDetentionCurfewEligibilityDate = LocalDate.of(2025, 3, 30),
@@ -445,7 +447,8 @@ class MigrationControllerTest : SqsIntegrationTestBase() {
       Prisoner(
         prisonerNumber = "A1234EE",
         bookingId = "50",
-        prisonId = "MDI",
+        prisonId = "ADI",
+        lastPrisonId = "MDI",
         topupSupervisionExpiryDate = null,
         licenceExpiryDate = null,
         homeDetentionCurfewEligibilityDate = LocalDate.of(2025, 3, 30),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/TestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/licences/TestData.kt
@@ -736,6 +736,7 @@ object TestData {
     "A1234AA",
     "10",
     "MDI",
+    lastPrisonId = "MDI",
     topupSupervisionExpiryDate = LocalDate.now(),
     licenceExpiryDate = LocalDate.now().minusDays(1),
     homeDetentionCurfewEligibilityDate = LocalDate.now().minusDays(2),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/softdelete/SoftDeleteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppshdcapi/softdelete/SoftDeleteServiceTest.kt
@@ -152,6 +152,7 @@ class SoftDeleteServiceTest {
       prisonerNumber = "A1234BC",
       bookingId = "1",
       prisonId = "MDI",
+      lastPrisonId = "MDI",
       topupSupervisionExpiryDate = null,
       licenceExpiryDate = null,
       homeDetentionCurfewEligibilityDate = null,

--- a/src/test/resources/test_data/migration/test_address_when_CAS2_address_requested_and_accepted.json
+++ b/src/test/resources/test_data/migration/test_address_when_CAS2_address_requested_and_accepted.json
@@ -11,8 +11,7 @@
     "dateOfBirth" : "1985-05-20"
   },
   "prison" : {
-    "prisonCode" : "MDI",
-    "prisonDescription" : "Manchester Prison"
+    "prisonCode" : "MDI"
   },
   "sentence" : {
     "sentenceStartDate" : "2020-01-01",

--- a/src/test/resources/test_data/migration/test_approved_premises_is_required_over_CAS2_address.json
+++ b/src/test/resources/test_data/migration/test_approved_premises_is_required_over_CAS2_address.json
@@ -11,8 +11,7 @@
     "dateOfBirth" : "1985-05-20"
   },
   "prison" : {
-    "prisonCode" : "MDI",
-    "prisonDescription" : "Manchester Prison"
+    "prisonCode" : "MDI"
   },
   "sentence" : {
     "sentenceStartDate" : "2020-01-01",

--- a/src/test/resources/test_data/migration/test_hdc_to_cvl.json
+++ b/src/test/resources/test_data/migration/test_hdc_to_cvl.json
@@ -11,8 +11,7 @@
     "dateOfBirth" : "1985-05-20"
   },
   "prison" : {
-    "prisonCode" : "MDI",
-    "prisonDescription" : "Manchester Prison"
+    "prisonCode" : "MDI"
   },
   "sentence" : {
     "sentenceStartDate" : "2020-01-01",

--- a/src/test/resources/test_data/migration/test_hdc_to_cvl_licence_1_of_batch.json
+++ b/src/test/resources/test_data/migration/test_hdc_to_cvl_licence_1_of_batch.json
@@ -11,8 +11,7 @@
     "dateOfBirth" : "1985-05-20"
   },
   "prison" : {
-    "prisonCode" : "MDI",
-    "prisonDescription" : "Manchester Prison"
+    "prisonCode" : "MDI"
   },
   "sentence" : {
     "sentenceStartDate" : "2020-01-01",

--- a/src/test/resources/test_data/migration/test_hdc_to_cvl_licence_2_of_batch.json
+++ b/src/test/resources/test_data/migration/test_hdc_to_cvl_licence_2_of_batch.json
@@ -11,8 +11,7 @@
     "dateOfBirth" : "1985-05-20"
   },
   "prison" : {
-    "prisonCode" : "MDI",
-    "prisonDescription" : "Manchester Prison"
+    "prisonCode" : "MDI"
   },
   "sentence" : {
     "sentenceStartDate" : "2020-01-01",

--- a/src/test/resources/test_data/migration/test_hdc_to_cvl_licence_3_of_batch.json
+++ b/src/test/resources/test_data/migration/test_hdc_to_cvl_licence_3_of_batch.json
@@ -11,8 +11,7 @@
     "dateOfBirth" : "1985-05-20"
   },
   "prison" : {
-    "prisonCode" : "MDI",
-    "prisonDescription" : "Manchester Prison"
+    "prisonCode" : "MDI"
   },
   "sentence" : {
     "sentenceStartDate" : "2020-01-01",

--- a/src/test/resources/test_data/migration/test_when_approved_premises_is_required_over_proposed_address.json
+++ b/src/test/resources/test_data/migration/test_when_approved_premises_is_required_over_proposed_address.json
@@ -11,8 +11,7 @@
     "dateOfBirth" : "1985-05-20"
   },
   "prison" : {
-    "prisonCode" : "MDI",
-    "prisonDescription" : "Manchester Prison"
+    "prisonCode" : "MDI"
   },
   "sentence" : {
     "sentenceStartDate" : "2020-01-01",

--- a/src/test/resources/test_data/migration/test_when_multiple-licences-with-same-booking-id-present-in-audit.json
+++ b/src/test/resources/test_data/migration/test_when_multiple-licences-with-same-booking-id-present-in-audit.json
@@ -11,8 +11,7 @@
     "dateOfBirth" : "1985-05-20"
   },
   "prison" : {
-    "prisonCode" : "MDI",
-    "prisonDescription" : "Manchester Prison"
+    "prisonCode" : "MDI"
   },
   "sentence" : {
     "sentenceStartDate" : "2020-01-01",

--- a/src/test/resources/test_data/migration/test_when_no_appointment_date_time_given.json
+++ b/src/test/resources/test_data/migration/test_when_no_appointment_date_time_given.json
@@ -11,8 +11,7 @@
     "dateOfBirth" : "1985-05-20"
   },
   "prison" : {
-    "prisonCode" : "MDI",
-    "prisonDescription" : "Manchester Prison"
+    "prisonCode" : "MDI"
   },
   "sentence" : {
     "sentenceStartDate" : "2020-01-01",

--- a/src/test/resources/test_data/migration/test_when_no_other_address_is_available_then_use_proposed_curfew_address.json
+++ b/src/test/resources/test_data/migration/test_when_no_other_address_is_available_then_use_proposed_curfew_address.json
@@ -11,8 +11,7 @@
     "dateOfBirth" : "1985-05-20"
   },
   "prison" : {
-    "prisonCode" : "MDI",
-    "prisonDescription" : "Manchester Prison"
+    "prisonCode" : "MDI"
   },
   "sentence" : {
     "sentenceStartDate" : "2020-01-01",

--- a/src/test/resources/test_data/migration/test_with_specific_curfew_days.json
+++ b/src/test/resources/test_data/migration/test_with_specific_curfew_days.json
@@ -11,8 +11,7 @@
     "dateOfBirth" : "1985-05-20"
   },
   "prison" : {
-    "prisonCode" : "MDI",
-    "prisonDescription" : "Manchester Prison"
+    "prisonCode" : "MDI"
   },
   "sentence" : {
     "sentenceStartDate" : "2020-01-01",


### PR DESCRIPTION
```
@Field(type = FieldType.Keyword)
@Schema(description = "The last i.e. final prison for the prisoner (which is the same as the prisonId if they are still inside prison)", example = "MDI")
@DiffableProperty(DiffCategory.LOCATION)
var lastPrisonId: String? = null
```
Using lastPrisonId instead to avoid getting OUT
