### PR TITLE
Remove local NVD cache configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -155,8 +155,3 @@ tasks {
 allOpen {
   annotation("jakarta.persistence.Entity")
 }
-
-dependencyCheck {
-  nvd.datafeedUrl = "file:///opt/vulnz/cache"
-  suppressionFiles.add("hdc-api-suppressions.xml")
-}


### PR DESCRIPTION
Configuration change required to support the move to Github Pages for the NVD Cache. As per [this conversation](https://mojdt.slack.com/archives/C06MWP0UKDE/p1784300758956369) - the local configuration overrides the OWASP workflow parameter